### PR TITLE
Rename action IDs for improved branch management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to NPM
         if: github.ref == 'refs/heads/main'
-        id: changesets-main
+        id: changesetsMain
         uses: changesets/action@v1
         with:
           publish: yarn release
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Release Pull Request
         if: github.ref == 'refs/heads/dev'
-        id: changesets-dev
+        id: changesetsDev
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## **User description**
Adjusted the action IDs in the GitHub workflow script to 'changesetsMain' for the main branch and 'changesetsDev' for the dev branch. This change better distinguishes the management of release pull requests for these two unique branches.


___

## **Type**
enhancement


___

## **Description**
- Renamed action IDs in the GitHub workflow to improve clarity between main and dev branch management.
- Action IDs changed to `changesetsMain` for the main branch and `changesetsDev` for the dev branch, enhancing the distinction between branch-specific workflows.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Renaming Action IDs for Clarity in Branch Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/release.yml

<li>Renamed action ID from <code>changesets-main</code> to <code>changesetsMain</code> for the main <br>branch.<br> <li> Renamed action ID from <code>changesets-dev</code> to <code>changesetsDev</code> for the dev <br>branch.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ElsiKora/DApiGate-SDK-Node/pull/7/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

